### PR TITLE
ci: add linting

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -19,3 +19,5 @@ jobs:
         run: pip install -r requirements_dev.txt
       - name: Lint with pylint
         run: pylint tests/tasks/*
+      - name: Lint with ruff
+        run: ruff check tests/tasks/*

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -1,0 +1,21 @@
+name: Crypt4GH Middleware Checks
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Run linting
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install requirements
+        run: pip install -r requirements_dev.txt
+      - name: Lint with pylint
+        run: pylint tests/tasks/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-crypt4gh
+crypt4gh==1.7

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 requests==2.32.1
 pytest==8.2.1
 pylint==3.2.2
+ruff==0.4.6

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,2 +1,3 @@
 requests==2.32.1
 pytest==8.2.1
+pylint==3.2.2

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-requests==2.32.1
-pytest==8.2.1
-pylint==3.2.2
-ruff==0.4.6
+requests~=2.32
+pytest~=8.2
+pylint~=3.2
+ruff~=0.4


### PR DESCRIPTION
Initializes CI workflow with linting. I saw that proTES uses both pylint and flake8. Should I use both as well?