### PR TITLE
feat: add executor decryption script

### DIFF
--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -69,13 +69,19 @@ def move_files(file_paths: list[Path], output_dir: Path) -> list[Path]:
     """Decrypt files in place.
 
     Args:
-        file_paths: A list of file paths.
+        file_paths: A list of file paths with unique file names.
         output_dir: Directory to move files to.
 
     Returns:
         A list containing the new file paths.
     """
-    output_paths = [output_dir/file_path.name for file_path in file_paths]
+    output_paths = []
+    existing_names = set()
+    for file_path in file_paths:
+        if file_path.name in existing_names:
+            raise ValueError(f"Duplicate file name found: {file_path.name}")
+        output_paths = [output_dir/file_path.name for file_path in file_paths]
+        existing_names.add(file_path.name)
     for src, dest in zip(file_paths, output_paths):
         shutil.move(src, dest)
     return output_paths
@@ -100,7 +106,7 @@ def main():
         "file_paths",
         nargs='+',
         type=Path,
-        help="Paths to the input files.")
+        help="Paths to the input files. File names must be unique.")
     parser.add_argument(
         "--output-dir",
         default=os.environ.get("TMPDIR", "./tmpdir"),

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -66,7 +66,7 @@ def decrypt_files(file_paths: list[Path], private_keys: list[bytes]):
 
 
 def move_files(file_paths: list[Path], output_dir: Path) -> list[Path]:
-    """Decrypt files in place.
+    """Move files to a specified output directory.
 
     Args:
         file_paths: A list of file paths with unique file names.

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -59,9 +59,9 @@ def decrypt_files(file_paths: list[Path], private_keys: list[bytes]):
                 decrypt(keys=key_tuples, infile=f_in, outfile=f_out)
                 shutil.move(f_out.name, file_path)
             except ValueError as e:
-                if str(e) == "Not a CRYPT4GH formatted file":
-                    continue
-                raise ValueError(f"Private key for {file_path} not provided") from e
+                if str(e) != "Not a CRYPT4GH formatted file":
+                    print(f"Private key for {file_path} not provided")
+                continue
 
 
 def move_files(file_paths: list[Path], output_dir: Path) -> list[Path]:
@@ -112,7 +112,7 @@ def main():
     try:
         decrypt_files(file_paths=new_paths, private_keys=keys)
     except Exception as e:
-        remove_files(args.output_dir)
+        remove_files(directory=args.output_dir)
         raise e
 
 

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -44,9 +44,6 @@ def decrypt_files(file_paths: list[Path], private_keys: list[bytes]):
     Args:
         file_paths: A list of file paths.
         private_keys: A list of private keys as byte objects.
-
-    Raises:
-        ValueError: If no private key for a Crypt4GH file is provided.
     """
     encryption_method_codes = {
         'ChaCha20': 0,

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -89,6 +89,9 @@ def remove_files(directory: Path):
 
     Args:
         directory: Directory that holds the files to be deleted.
+
+    Raises:
+        ValueError if specified directory does not exist.
     """
     if not directory.is_dir():
         raise ValueError(f"Could not remove files: {directory} is not a directory.")

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -1,0 +1,89 @@
+"""Identify and decrypt Crypt4GH keys and files.
+
+Decrypts crypt4GH files given a list of files and places the output in a specified
+directory. If a file is not Crypt4GH-encrypted, it moves the file to the output directory
+without alteration. If a Crypt4GH file is included, the private key associated with that
+file must be provided.
+
+Example:
+    python3 decrypt.py --ouput-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
+"""
+import os
+from argparse import ArgumentParser
+from pathlib import Path
+from crypt4gh.lib import decrypt
+from crypt4gh.keys import get_private_key
+
+
+def get_private_keys(file_paths: list[Path]) -> list[bytes]:
+    """Retrieve private keys from a list of files.
+
+    Args:
+        file_paths (list[Path]): A list of file paths.
+
+    Returns:
+        list[bytes]: A list of retrieved private keys as byte objects.
+    """
+    private_keys = []
+    for file_path in file_paths:
+        try:
+            key = get_private_key(Path(file_path), lambda x: '')
+            private_keys.append(key)
+        except ValueError:
+            continue
+    return private_keys
+
+
+def decrypt_files(
+        file_paths: list[Path],
+        private_keys: list[bytes],
+        output_path: Path) -> None:
+    """Decrypt files and save to specified output directory.
+
+    Args:
+        file_paths (list[Path]): A list of file paths.
+        private_keys (list[bytes]): A list of private keys as byte objects.
+        output_path: (Path): Directory to place decrypted files in.
+
+    Raises:
+        ValueError: If no private key for a Crypt4GH file is provided
+    """
+    for file_path in file_paths:
+        with open(file_path, "rb") as f_in:
+            filename = file_path.name
+            try:
+                with open(output_path/filename, "wb") as f_out:
+                    decrypt([(0, pk, "") for pk in private_keys], f_in, f_out)
+            except ValueError as e:
+                if str(e) == "Not a CRYPT4GH formatted file":
+                    continue
+                raise ValueError(f"Private key for {file_path} not provided") from e
+
+
+def move_files(file_paths: list[Path], output_path: Path) -> None:
+    """Move files that are not in the specified output directory to the directory.
+
+    Args:
+        file_paths (list[Path]): A list of file paths.
+        output_path: (Path): Directory to place decrypted files in.
+    """
+    for file_path in file_paths:
+        filename = file_path.name
+        if not (output_path/filename).exists():
+            os.replace(file_path, output_path/filename)
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument("file_paths", nargs='+')
+    parser.add_argument(
+        "--output-dir",
+        required=True,
+        dest="output_dir",
+        help="Directory to upload files to.")
+
+    output_dir = Path(parser.parse_args().output_dir)
+    paths = [Path(path) for path in parser.parse_args().file_paths]
+    keys = get_private_keys(paths)
+    decrypt_files(paths, keys, output_dir)
+    move_files(paths, output_dir)

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -82,8 +82,9 @@ if __name__ == "__main__":
         dest="output_dir",
         help="Directory to upload files to.")
 
-    output_dir = Path(parser.parse_args().output_dir)
-    paths = [Path(path) for path in parser.parse_args().file_paths]
+    args = parser.parse_args()
+    output_dir = Path(args.output_dir)
+    paths = [Path(path) for path in args.file_paths]
     keys = get_private_keys(paths)
     decrypt_files(paths, keys, output_dir)
     move_files(paths, output_dir)

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -99,8 +99,12 @@ def remove_files(directory: Path):
         subprocess.run(["rm", "-P", str(file)], check=True)
 
 
-def main():
-    """Parse command-line arguments"""
+def get_args():
+    """Parse command-line arguments.
+
+    Returns:
+        argparse.ArgumentParser object containing the file_paths and output_dir arguments
+    """
     parser = ArgumentParser()
     parser.add_argument(
         "file_paths",
@@ -113,7 +117,12 @@ def main():
         help="Directory to upload files to. Defaults to $TMPDIR if set, otherwise './tmpdir'.",
         type=Path)
 
-    args = parser.parse_args()
+    return parser.parse_args()
+
+
+def main():
+    """Coordinate execution of script."""
+    args = get_args()
     new_paths = move_files(file_paths=args.file_paths, output_dir=args.output_dir)
     keys = get_private_keys(file_paths=new_paths)
     try:

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -8,9 +8,10 @@ file must be provided.
 Example:
     python3 decrypt.py --output-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
 """
-import shutil
 from argparse import ArgumentParser
 from pathlib import Path
+import shutil
+
 from crypt4gh.lib import decrypt  # type: ignore
 from crypt4gh.keys import get_private_key  # type: ignore
 

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -11,8 +11,8 @@ Example:
 import os
 from argparse import ArgumentParser
 from pathlib import Path
-from crypt4gh.lib import decrypt
-from crypt4gh.keys import get_private_key
+from crypt4gh.lib import decrypt  # type: ignore
+from crypt4gh.keys import get_private_key  # type: ignore
 
 
 def get_private_keys(file_paths: list[Path]) -> list[bytes]:

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -57,7 +57,7 @@ def decrypt_files(file_paths: list[Path], private_keys: list[bytes]):
     for file_path in file_paths:
         with open(file_path, "rb") as f_in, NamedTemporaryFile() as f_out:
             try:
-                decrypt(keys=key_tuples, infile=f_in, outfile=f_out)
+                decrypt(keys=key_tuples, infile=f_in, outfile=f_out)  # Checks for magic
                 shutil.move(f_out.name, file_path)
             except ValueError as e:
                 if str(e) != "Not a CRYPT4GH formatted file":

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -20,10 +20,10 @@ def get_private_keys(file_paths: list[Path]) -> list[bytes]:
     """Retrieve private keys from a list of files.
 
     Args:
-        file_paths (list[Path]): A list of file paths.
+        file_paths: A list of file paths.
 
     Returns:
-        list[bytes]: A list of retrieved private keys as byte objects.
+        A list of retrieved private keys as byte objects.
     """
     private_keys = []
     for file_path in file_paths:
@@ -41,8 +41,8 @@ def decrypt_files(
     """Decrypt files and save to specified output directory.
 
     Args:
-        file_paths (list[Path]): A list of file paths.
-        private_keys (list[bytes]): A list of private keys as byte objects.
+        file_paths: A list of file paths.
+        private_keys: A list of private keys as byte objects.
 
     Raises:
         ValueError: If no private key for a Crypt4GH file is provided.

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -99,7 +99,7 @@ def main():
         "file_paths",
         nargs='+',
         type=Path,
-        help="Paths to input files.")
+        help="Paths to the input files.")
     parser.add_argument(
         "--output-dir",
         required=True,

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -75,7 +75,7 @@ def move_files(file_paths: list[Path], output_path: Path) -> None:
 
 if __name__ == "__main__":
     parser = ArgumentParser()
-    parser.add_argument("file_paths", nargs='+')
+    parser.add_argument("file_paths", nargs='+', type=Path)
     parser.add_argument(
         "--output-dir",
         required=True,
@@ -84,7 +84,7 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     output_dir = Path(args.output_dir)
-    paths = [Path(path) for path in args.file_paths]
+    paths = args.file_paths
     keys = get_private_keys(paths)
     decrypt_files(paths, keys, output_dir)
     move_files(paths, output_dir)

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -6,7 +6,7 @@ without alteration. If a Crypt4GH file is included, the private key associated w
 file must be provided.
 
 Example:
-    python3 decrypt.py --ouput-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
+    python3 decrypt.py --output-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
 """
 import os
 from argparse import ArgumentParser
@@ -46,7 +46,7 @@ def decrypt_files(
         output_path: (Path): Directory to place decrypted files in.
 
     Raises:
-        ValueError: If no private key for a Crypt4GH file is provided
+        ValueError: If no private key for a Crypt4GH file is provided.
     """
     for file_path in file_paths:
         with open(file_path, "rb") as f_in:

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -28,7 +28,7 @@ def get_private_keys(file_paths: list[Path]) -> list[bytes]:
     private_keys = []
     for file_path in file_paths:
         try:
-            key = get_private_key(Path(file_path), lambda x: '')
+            key = get_private_key(file_path, callback=lambda x: '')  # Callback returns sk password
             private_keys.append(key)
         except ValueError:
             continue

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -8,6 +8,7 @@ Example:
     python3 decrypt.py --output-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
 """
 from argparse import ArgumentParser
+import os
 from pathlib import Path
 import shutil
 import subprocess
@@ -102,8 +103,8 @@ def main():
         help="Paths to the input files.")
     parser.add_argument(
         "--output-dir",
-        required=True,
-        help="Directory to upload files to.",
+        default=os.environ.get("TMPDIR", "./tmpdir"),
+        help="Directory to upload files to. Defaults to $TMPDIR if set, otherwise './tmpdir'.",
         type=Path)
 
     args = parser.parse_args()

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -1,9 +1,8 @@
 """Identify and decrypt Crypt4GH keys and files.
 
-Decrypts crypt4GH files given a list of files and places the output in a specified
-directory. If a file is not Crypt4GH-encrypted, it moves the file to the output directory
-without alteration. If a Crypt4GH file is included, the private key associated with that
-file must be provided.
+Moves all files in a given list and places the output in a specified directory. Any encrypted files
+are subsequently decrypted in place. If a Crypt4GH file is included, the private key associated with
+that file must be provided.
 
 Example:
     python3 decrypt.py --output-dir /outputs/ file.txt file.c4gh sk.sec pk.pub
@@ -30,16 +29,14 @@ def get_private_keys(file_paths: list[Path]) -> list[bytes]:
     for file_path in file_paths:
         try:
             # Callback returns password of sk
-            key = get_private_key(file_path, callback=lambda x: '')
+            key = get_private_key(filepath=file_path, callback=lambda x: '')
             private_keys.append(key)
         except ValueError:
             continue
     return private_keys
 
 
-def decrypt_files(
-        file_paths: list[Path],
-        private_keys: list[bytes]):
+def decrypt_files(file_paths: list[Path], private_keys: list[bytes]):
     """Decrypt files in place.
 
     Args:
@@ -66,19 +63,41 @@ def decrypt_files(
                 raise ValueError(f"Private key for {file_path} not provided") from e
 
 
-if __name__ == "__main__":
+def move_files(file_paths: list[Path], output_dir: Path) -> list[Path]:
+    """Decrypt files in place.
+
+        Args:
+            file_paths: A list of file paths.
+            output_dir: Directory to move files to.
+
+        Returns:
+            A list of the new file paths.
+        """
+    output_paths = [output_dir/file_path.name for file_path in file_paths]
+    for src, dest in zip(file_paths, output_paths):
+        shutil.move(src, dest)
+    return output_paths
+
+
+def main():
+    """Parse command-line arguments"""
     parser = ArgumentParser()
-    parser.add_argument("file_paths", nargs='+', type=Path)
+    parser.add_argument(
+        "file_paths",
+        nargs='+',
+        type=Path,
+        help="Paths to input files.")
     parser.add_argument(
         "--output-dir",
         required=True,
-        dest="output_dir",
         help="Directory to upload files to.",
         type=Path)
 
     args = parser.parse_args()
-    paths = [args.output_dir/file_path.name for file_path in args.file_paths]
-    for src, dest in zip(args.file_paths, paths):
-        shutil.move(src, dest)
-    keys = get_private_keys(paths)
-    decrypt_files(paths, keys)
+    new_paths = move_files(file_paths=args.file_paths, output_dir=args.output_dir)
+    keys = get_private_keys(new_paths)
+    decrypt_files(file_paths=new_paths, private_keys=keys)
+
+
+if __name__ == "__main__":
+    main()

--- a/middleware/decrypt.py
+++ b/middleware/decrypt.py
@@ -81,7 +81,7 @@ def move_files(file_paths: list[Path], output_dir: Path) -> list[Path]:
 
 
 def remove_files(directory: Path):
-    """Securely removes all files in a directory using srm.
+    """Rewrites and removes all files in a directory using rm -P.
 
     Args:
         directory: Directory that holds the files to be deleted.
@@ -89,7 +89,7 @@ def remove_files(directory: Path):
     if not directory.is_dir():
         raise ValueError(f"Could not remove files: {directory} is not a directory.")
     for file in directory.iterdir():
-        subprocess.run(["srm", str(file)], check=True)
+        subprocess.run(["rm", "-P", str(file)], check=True)
 
 
 def main():


### PR DESCRIPTION
This is the python script that will be used by the decryption executor to decrypt the crypt4gh files and place them in a volume. The middleware will parse through all the input locations listed in the original request and feed them to decrypt.py in the first executor. Here's an illustration of exactly what the middleware will do (and how decrypt.py fits into the workflow):

<img width="737" alt="Screenshot 2024-06-16 at 7 34 58 PM" src="https://github.com/elixir-cloud-aai/protes-middleware-crypt4gh/assets/66563785/12561fbf-21a5-4789-9c69-75bf37115d03">


Since it doesn't know what files are crypt4gh files beforehand, the script places all files (regardless of whether or not they are encrypted) in the new volume. If a file is not a crypt4gh file, it gets moved without alteration. If it is a crypt4gh file, the decrypted version is placed in the new volume.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds a new Python script (`decrypt.py`) that identifies and decrypts Crypt4GH files, moving decrypted files to a specified output directory. Non-encrypted files are moved without alteration.

* **New Features**:
    - Introduced a Python script (`decrypt.py`) to identify and decrypt Crypt4GH files, placing them in a specified output directory.

<!-- Generated by sourcery-ai[bot]: end summary -->