### PR TITLE
fix: include all test files in linting

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Install dependencies
         run: poetry install
       - name: Lint with pylint
-        run: poetry run pylint tests/tasks/* crypt4gh_middleware/*
+        run: poetry run pylint tests/* crypt4gh_middleware/*
       - name: Lint with ruff
-        run: poetry run ruff check tests/tasks/* crypt4gh_middleware/*
+        run: poetry run ruff check tests/* crypt4gh_middleware/*
       - name: Type checking with mypy
         run: poetry run mypy crypt4gh_middleware


### PR DESCRIPTION
Change CI to include decryption tests in linting

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow to ensure that all test files are included in the linting process using pylint and ruff.

- **CI**:
    - Updated CI workflow to include all test files in linting with pylint and ruff.

<!-- Generated by sourcery-ai[bot]: end summary -->