### PR TITLE
test: add get_args tests

### DIFF
--- a/tests/decryption/test_decrypt.py
+++ b/tests/decryption/test_decrypt.py
@@ -153,6 +153,7 @@ class TestMoveFiles:
 
 @contextlib.contextmanager
 def patch_cli(args):
+    """Context manager that patches sys.argv."""
     with mock.patch("sys.argv", args):
         yield
 

--- a/tests/decryption/test_decrypt.py
+++ b/tests/decryption/test_decrypt.py
@@ -170,12 +170,12 @@ class TestGetArgs:
 
     def test_invalid_argument(self):
         """Test that a system exit occurs when an invalid argument is passed."""
-        with mock.patch("sys.argv", ["decrypt.py", "--bad-argument", "dir", "file.txt"]):
-            with pytest.raises(SystemExit):
-                get_args()
+        with (mock.patch("sys.argv", ["decrypt.py", "--bad-argument", "dir", "file.txt"]),
+              pytest.raises(SystemExit)):
+            get_args()
 
     def test_no_file_paths(self):
         """Test that a system exit occurs when no file paths are passed."""
-        with mock.patch("sys.argv", ["decrypt.py", "--output-dir", "dir"]):
-            with pytest.raises(SystemExit):
-                get_args()
+        with (mock.patch("sys.argv", ["decrypt.py", "--output-dir", "dir"]),
+              pytest.raises(SystemExit)):
+            get_args()

--- a/tests/decryption/test_decrypt.py
+++ b/tests/decryption/test_decrypt.py
@@ -1,5 +1,4 @@
 """Tests for decrypt.py"""
-import contextlib
 import os
 from pathlib import Path
 import shutil
@@ -14,6 +13,7 @@ from crypt4gh_middleware.decrypt import (
     move_files,
     get_args
 )
+from tests.utils import patch_cli
 
 INPUT_DIR = Path(__file__).parents[2]/"inputs"
 INPUT_TEXT = "hello world from the input!"
@@ -149,13 +149,6 @@ class TestMoveFiles:
         output_dir.chmod(0o400)
         with pytest.raises(PermissionError):
             move_files(file_paths=[INPUT_DIR/"hello.txt"], output_dir=output_dir)
-
-
-@contextlib.contextmanager
-def patch_cli(args):
-    """Context manager that patches sys.argv."""
-    with mock.patch("sys.argv", args):
-        yield
 
 
 class TestGetArgs:

--- a/tests/decryption/test_decrypt.py
+++ b/tests/decryption/test_decrypt.py
@@ -162,9 +162,10 @@ class TestGetArgs:
 
     def test_default_output_dir(self):
         """Test that output_dir defaults to $TMPDIR when no directory is passed."""
-        with mock.patch("sys.argv", ["decrypt.py", "file.txt"]):
+        with (mock.patch("sys.argv", ["decrypt.py", "file.txt"]),
+              mock.patch.dict(os.environ, {"TMPDIR": "/mock/tmpdir"})):
             args = get_args()
-            assert args.output_dir == Path(os.getenv("TMPDIR"))
+            assert args.output_dir == Path("/mock/tmpdir")
             assert args.file_paths == [Path("file.txt")]
 
     def test_invalid_argument(self):

--- a/tests/decryption/test_decrypt.py
+++ b/tests/decryption/test_decrypt.py
@@ -160,6 +160,13 @@ class TestGetArgs:
             assert args.output_dir == Path("dir")
             assert args.file_paths == [Path("file.txt")]
 
+    def test_multiple_files(self):
+        """Test that multiple file paths can be passed."""
+        files = ["file.txt", "file2.txt", "file3.txt"]
+        with mock.patch("sys.argv", ["decrypt.py"] + files):
+            args = get_args()
+            assert args.file_paths == [Path(file) for file in files]
+
     def test_default_output_dir(self):
         """Test that output_dir defaults to $TMPDIR when no directory is passed."""
         with (mock.patch("sys.argv", ["decrypt.py", "file.txt"]),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,15 @@
 """ Utility functions for tests."""
 from functools import wraps
+import contextlib
 import signal
+from unittest import mock
+
+
+@contextlib.contextmanager
+def patch_cli(args):
+    """Context manager that patches sys.argv."""
+    with mock.patch("sys.argv", args):
+        yield
 
 
 def timeout(time_limit):


### PR DESCRIPTION
Adds tests for [get_args()](https://github.com/elixir-cloud-aai/protes-middleware-crypt4gh/blob/main/crypt4gh_middleware/decrypt.py#L110).

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces unit tests for the `get_args` function, covering scenarios such as correct argument parsing, default output directory, invalid arguments, and missing file paths.

- **Tests**:
    - Added unit tests for the `get_args` function to ensure correct argument parsing, default values, and error handling.

<!-- Generated by sourcery-ai[bot]: end summary -->