### PR TITLE
refactor: use temporary directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,5 +174,3 @@ poetry.toml
 pyrightconfig.json
 
 # End of https://www.toptal.com/developers/gitignore/api/python
-
-outputs/

--- a/tests/tasks/task_bodies.py
+++ b/tests/tasks/task_bodies.py
@@ -1,10 +1,11 @@
 """TES task request bodies used by tests"""
 
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 DIR = Path(__file__).parents[2]
 input_dir = DIR / "inputs"
-output_dir = DIR / "outputs"
+tmp_dir = TemporaryDirectory()  # pylint: disable=consider-using-with
 
 uppercase_task_body = {
         "name": "Hello world",
@@ -22,7 +23,7 @@ uppercase_task_body = {
         ],
         "outputs": [
             {
-                "url": f"file://{output_dir}/hello-upper.txt",
+                "url": f"file://{tmp_dir.name}/hello-upper.txt",
                 "path": "/outputs/hello-upper.txt",
                 "type": "FILE"
             }
@@ -61,7 +62,7 @@ decryption_task_body = {
         ],
         "outputs": [
             {
-                "url": f"file://{output_dir}/hello-decrypted.txt",
+                "url": f"file://{tmp_dir.name}/hello-decrypted.txt",
                 "path": "/outputs/hello-decrypted.txt",
                 "type": "FILE"
             }
@@ -105,7 +106,7 @@ uppercase_task_with_decryption_body = {
     ],
     "outputs": [
         {
-            "url": f"file://{output_dir}/hello-upper-decrypt.txt",
+            "url": f"file://{tmp_dir.name}/hello-upper-decrypt.txt",
             "path": "/outputs/hello-upper-decrypt.txt",
             "type": "FILE"
         }

--- a/tests/tasks/task_bodies.py
+++ b/tests/tasks/task_bodies.py
@@ -1,13 +1,14 @@
 """TES task request bodies used by tests"""
 
 from pathlib import Path
-from tempfile import TemporaryDirectory
 
 DIR = Path(__file__).parents[2]
 input_dir = DIR / "inputs"
-tmp_dir = TemporaryDirectory()  # pylint: disable=consider-using-with
 
-uppercase_task_body = {
+
+def get_uppercase_task_body(tmp_dir):
+    """Returns TES task body that makes the contents of a file uppercase."""
+    return {
         "name": "Hello world",
         "inputs": [
             {
@@ -23,7 +24,7 @@ uppercase_task_body = {
         ],
         "outputs": [
             {
-                "url": f"file://{tmp_dir.name}/hello-upper.txt",
+                "url": f"file://{tmp_dir}/hello-upper.txt",
                 "path": "/outputs/hello-upper.txt",
                 "type": "FILE"
             }
@@ -41,7 +42,10 @@ uppercase_task_body = {
         ]
     }
 
-decryption_task_body = {
+
+def get_decryption_task_body(tmp_dir):
+    """Returns TES task body that decrypts a crypt4GH file."""
+    return {
         "name": "Decrypt with secret key as environment variable",
         "inputs": [
             {
@@ -62,7 +66,7 @@ decryption_task_body = {
         ],
         "outputs": [
             {
-                "url": f"file://{tmp_dir.name}/hello-decrypted.txt",
+                "url": f"file://{tmp_dir}/hello-decrypted.txt",
                 "path": "/outputs/hello-decrypted.txt",
                 "type": "FILE"
             }
@@ -80,58 +84,61 @@ decryption_task_body = {
         ]
     }
 
-uppercase_task_with_decryption_body = {
-    "name": "Decrypt with secret key as environment variable",
-    "inputs": [
-        {
-            "url": f"file://{input_dir}/hello.c4gh",
-            "path": "/inputs/hello.c4gh",
-            "type": "FILE"
-        },
-        {
-            "url": f"file://{input_dir}/alice.sec",
-            "path": "/inputs/alice.sec",
-            "type": "FILE"
-        },
-        {
-            "url": f"file://{input_dir}/decrypt.sh",
-            "path": "/inputs/decrypt.sh",
-            "type": "FILE"
-        },
-        {
-            "url": f"file://{input_dir}/make_uppercase.py",
-            "path": "/inputs/make_uppercase.py",
-            "type": "FILE"
-        }
-    ],
-    "outputs": [
-        {
-            "url": f"file://{tmp_dir.name}/hello-upper-decrypt.txt",
-            "path": "/outputs/hello-upper-decrypt.txt",
-            "type": "FILE"
-        }
-    ],
-    "executors": [
-        {
-            "image": "athitheyag/c4gh:1.0",
-            "command": ["bash", "/inputs/decrypt.sh"],
-            "env": {
-                "INPUT_LOC": "/inputs/hello.c4gh",
-                "OUTPUT_LOC": "/vol/A/inputs/hello.txt",
-                "SECRET": "/inputs/alice.sec"
+
+def get_uppercase_task_with_decryption_body(tmp_dir):
+    """Returns TES task body that makes the contents of a crypt4GH file uppercase."""
+    return {
+        "name": "Decrypt with secret key as environment variable",
+        "inputs": [
+            {
+                "url": f"file://{input_dir}/hello.c4gh",
+                "path": "/inputs/hello.c4gh",
+                "type": "FILE"
+            },
+            {
+                "url": f"file://{input_dir}/alice.sec",
+                "path": "/inputs/alice.sec",
+                "type": "FILE"
+            },
+            {
+                "url": f"file://{input_dir}/decrypt.sh",
+                "path": "/inputs/decrypt.sh",
+                "type": "FILE"
+            },
+            {
+                "url": f"file://{input_dir}/make_uppercase.py",
+                "path": "/inputs/make_uppercase.py",
+                "type": "FILE"
             }
-        },
-        {
-            "image": "python:3",
-            "command": [
-                "python3",
-                "/inputs/make_uppercase.py",
-                "/vol/A/inputs/hello.txt"
-            ],
-            "stdout": "/outputs/hello-upper-decrypt.txt"
-        }
-    ],
-    "volumes": [
-        "/vol/A/inputs"
-    ]
+        ],
+        "outputs": [
+            {
+                "url": f"file://{tmp_dir}/hello-upper-decrypt.txt",
+                "path": "/outputs/hello-upper-decrypt.txt",
+                "type": "FILE"
+            }
+        ],
+        "executors": [
+            {
+                "image": "athitheyag/c4gh:1.0",
+                "command": ["bash", "/inputs/decrypt.sh"],
+                "env": {
+                    "INPUT_LOC": "/inputs/hello.c4gh",
+                    "OUTPUT_LOC": "/vol/A/inputs/hello.txt",
+                    "SECRET": "/inputs/alice.sec"
+                }
+            },
+            {
+                "image": "python:3",
+                "command": [
+                    "python3",
+                    "/inputs/make_uppercase.py",
+                    "/vol/A/inputs/hello.txt"
+                ],
+                "stdout": "/outputs/hello-upper-decrypt.txt"
+            }
+        ],
+        "volumes": [
+            "/vol/A/inputs"
+        ]
 }

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -19,12 +19,11 @@ TES_URL = "http://localhost:8090/ga4gh/tes/v1"
 HEADERS = {"accept": "application/json", "Content-Type": "application/json"}
 WAIT_STATUSES = ("UNKNOWN", "INITIALIZING", "RUNNING", "QUEUED")
 INPUT_TEXT = "hello world from the input!"
-OUTPUT_DIR = Path(tmp_dir.name)
 
 
-def wait_for_file_download(filename):
+def wait_for_file_download(filename, output_path):
     """Waits for file with given filename to download."""
-    while not (OUTPUT_DIR/filename).exists():
+    while not (output_path/filename).exists():
         sleep(1)
 
 
@@ -65,11 +64,11 @@ def test_task(task, final_task_info, filename, expected_output):  # pylint: disa
     """Test tasks for successful completion and intended behavior."""
     assert final_task_info["state"] == "COMPLETE"
 
-    wait_for_file_download(filename)
-
-    with open(OUTPUT_DIR/filename, encoding="utf-8") as f:
-        output = f.read()
-        assert output == expected_output
-        true_result = output.isupper() if "upper" in filename else not output.isupper()
-        assert true_result
-        tmp_dir.cleanup()
+    with tmp_dir as output_dir:
+        output_path = Path(output_dir)
+        wait_for_file_download(filename=filename, output_path=output_path)
+        with open(output_path/filename, encoding="utf-8") as f:
+            output = f.read()
+            assert output == expected_output
+            true_result = output.isupper() if "upper" in filename else not output.isupper()
+            assert true_result

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -1,13 +1,14 @@
 """Tests for I/O and decryption tasks"""
 
 import json
+from pathlib import Path
 from time import sleep
 
 import pytest
 import requests
 
 from task_bodies import (
-    output_dir,
+    tmp_dir,
     uppercase_task_body,
     decryption_task_body,
     uppercase_task_with_decryption_body
@@ -18,11 +19,12 @@ TES_URL = "http://localhost:8090/ga4gh/tes/v1"
 HEADERS = {"accept": "application/json", "Content-Type": "application/json"}
 WAIT_STATUSES = ("UNKNOWN", "INITIALIZING", "RUNNING", "QUEUED")
 INPUT_TEXT = "hello world from the input!"
+OUTPUT_DIR = Path(tmp_dir.name)
 
 
 def wait_for_file_download(filename):
     """Waits for file with given filename to download."""
-    while not (output_dir/filename).exists():
+    while not (OUTPUT_DIR/filename).exists():
         sleep(1)
 
 
@@ -65,8 +67,9 @@ def test_task(task, final_task_info, filename, expected_output):  # pylint: disa
 
     wait_for_file_download(filename)
 
-    with open(output_dir/filename, encoding="utf-8") as f:
+    with open(OUTPUT_DIR/filename, encoding="utf-8") as f:
         output = f.read()
         assert output == expected_output
         true_result = output.isupper() if "upper" in filename else not output.isupper()
         assert true_result
+        tmp_dir.cleanup()

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -9,9 +9,9 @@ import pytest
 import requests
 
 from task_bodies import (
-    get_uppercase_task_body,
     get_decryption_task_body,
-    get_uppercase_task_with_decryption_body
+    get_uppercase_task_body,
+    get_uppercase_task_with_decryption_body,
 )
 from tests.utils import timeout
 

--- a/tests/tasks/test_tasks.py
+++ b/tests/tasks/test_tasks.py
@@ -2,16 +2,16 @@
 
 import json
 from pathlib import Path
+from tempfile import TemporaryDirectory
 from time import sleep
 
 import pytest
 import requests
 
 from task_bodies import (
-    tmp_dir,
-    uppercase_task_body,
-    decryption_task_body,
-    uppercase_task_with_decryption_body
+    get_uppercase_task_body,
+    get_decryption_task_body,
+    get_uppercase_task_with_decryption_body
 )
 from tests.utils import timeout
 
@@ -27,11 +27,17 @@ def wait_for_file_download(filename, output_path):
         sleep(1)
 
 
+@pytest.fixture(name="output_dir")
+def fixture_output_dir():
+    """Returns temporary directory to store task outputs."""
+    return Path(TemporaryDirectory().name)
+
+
 @pytest.fixture(name="task")
-def fixture_task(request):
+def fixture_task(request, output_dir):
     """Returns response received after creating task."""
     return requests.post(
-        url=f"{TES_URL}/tasks", headers=HEADERS, json=request.param
+        url=f"{TES_URL}/tasks", headers=HEADERS, json=request.param(output_dir)
     )
 
 
@@ -55,20 +61,18 @@ def fixture_final_task_info(task):
 
 
 @pytest.mark.parametrize("task,filename,expected_output", [
-    (uppercase_task_body, "hello-upper.txt", INPUT_TEXT.upper()),
-    (decryption_task_body, "hello-decrypted.txt", INPUT_TEXT),
-    (uppercase_task_with_decryption_body, "hello-upper-decrypt.txt", INPUT_TEXT.upper())
+    (get_uppercase_task_body, "hello-upper.txt", INPUT_TEXT.upper()),
+    (get_decryption_task_body, "hello-decrypted.txt", INPUT_TEXT),
+    (get_uppercase_task_with_decryption_body, "hello-upper-decrypt.txt", INPUT_TEXT.upper())
 ], indirect=["task"])
 @timeout(time_limit=10)
-def test_task(task, final_task_info, filename, expected_output):  # pylint: disable=unused-argument
+def test_task(task, final_task_info, filename, expected_output, output_dir):  # pylint: disable=unused-argument
     """Test tasks for successful completion and intended behavior."""
     assert final_task_info["state"] == "COMPLETE"
 
-    with tmp_dir as output_dir:
-        output_path = Path(output_dir)
-        wait_for_file_download(filename=filename, output_path=output_path)
-        with open(output_path/filename, encoding="utf-8") as f:
-            output = f.read()
-            assert output == expected_output
-            true_result = output.isupper() if "upper" in filename else not output.isupper()
-            assert true_result
+    wait_for_file_download(filename=filename, output_path=output_dir)
+    with open(output_dir/filename, encoding="utf-8") as f:
+        output = f.read()
+        assert output == expected_output
+        true_result = output.isupper() if "upper" in filename else not output.isupper()
+        assert true_result


### PR DESCRIPTION
Places outputs of task in temporary directory rather than in `outputs/`. Consequently removes `outputs/` from gitignore.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Refactor task output handling to use a temporary directory, update related test cases, and remove 'outputs/' directory from .gitignore.

Enhancements:
- Refactor task output handling to use a temporary directory instead of a fixed 'outputs/' directory.

Tests:
- Update test cases to accommodate the use of a temporary directory for task outputs.

Chores:
- Remove 'outputs/' directory from .gitignore.

<!-- Generated by sourcery-ai[bot]: end summary -->